### PR TITLE
Remove dependency on bc

### DIFF
--- a/certdays.sh
+++ b/certdays.sh
@@ -6,7 +6,7 @@ tail -n 1                                                   | \
 cut -d= -f2`
 certsec=`date +%s -d "$certdate"`
 nowsec=`date +%s`
-days=`echo "($certsec-$nowsec) / ( 60*60*24 )" | bc`
+days=`echo "$((($certsec-$nowsec)/(60*60*24)))"`
 
 echo "$1: $days"
 


### PR DESCRIPTION
I adapted this for an ansible playbook in my environment, but bc wasn't available in the target environment.  Bash can do the same math, so we don't need bc.